### PR TITLE
Scrape facebook post comments and user data

### DIFF
--- a/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/FacebookCommentAnalyzer.API.csproj
+++ b/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/FacebookCommentAnalyzer.API.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.47.0" />
   </ItemGroup>
 
 </Project>

--- a/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Models/FacebookComment.cs
+++ b/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Models/FacebookComment.cs
@@ -49,6 +49,9 @@ namespace FacebookCommentAnalyzer.API.Models
 
         [JsonPropertyName("picture")]
         public FacebookPicture Picture { get; set; } = new();
+
+        // Scraping-only convenience: user's profile URL if available
+        public string ProfileUrl { get; set; } = string.Empty;
     }
 
     public class FacebookPicture

--- a/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Program.cs
+++ b/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Program.cs
@@ -11,6 +11,7 @@ var facebookConfig = builder.Configuration.GetSection("FacebookApi").Get<Faceboo
 builder.Services.AddSingleton(facebookConfig ?? new FacebookApiConfig());
 
 builder.Services.AddScoped<IFacebookService, FacebookService>();
+builder.Services.AddScoped<IFacebookScrapeService, FacebookScrapeService>();
 
 // Add CORS
 builder.Services.AddCors(options =>

--- a/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Services/FacebookScrapeService.cs
+++ b/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Services/FacebookScrapeService.cs
@@ -1,0 +1,229 @@
+using FacebookCommentAnalyzer.API.Models;
+using Microsoft.Playwright;
+
+namespace FacebookCommentAnalyzer.API.Services
+{
+	public class FacebookScrapeService : IFacebookScrapeService
+	{
+		private readonly ILogger<FacebookScrapeService> _logger;
+
+		public FacebookScrapeService(ILogger<FacebookScrapeService> logger)
+		{
+			_logger = logger;
+		}
+
+		public async Task<List<FacebookComment>> ScrapeCommentsAsync(string postUrl, bool checkShare, CancellationToken cancellationToken = default)
+		{
+			var normalizedUrl = NormalizeToMobileBasic(postUrl);
+			var comments = new List<FacebookComment>();
+
+			try
+			{
+				using var playwright = await Playwright.CreateAsync();
+				await EnsureBrowsersInstalled(playwright, cancellationToken);
+
+				await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+				{
+					headless = true
+				});
+				var context = await browser.NewContextAsync(new BrowserNewContextOptions
+				{
+					UserAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123 Safari/537.36",
+					Locale = "en-US"
+				});
+				var page = await context.NewPageAsync();
+
+				await page.GotoAsync(normalizedUrl, new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 60000 });
+
+				// If there is a link to view full story, click it
+				var fullStory = await page.QuerySelectorAsync("a:has-text('Full Story')");
+				if (fullStory != null)
+				{
+					await Task.WhenAll(page.WaitForLoadStateAsync(LoadState.NetworkIdle), fullStory.ClickAsync());
+				}
+
+				// Load more comments by following pagination on mbasic
+				while (true)
+				{
+					comments.AddRange(await ExtractCommentsFromCurrentPageAsync(page));
+
+					var moreLink = await page.QuerySelectorAsync("a:has-text('View more comments')");
+					if (moreLink == null)
+					{
+						break;
+					}
+					await Task.WhenAll(page.WaitForLoadStateAsync(LoadState.NetworkIdle), moreLink.ClickAsync());
+				}
+
+				// De-duplicate by comment Id if present
+				comments = comments
+					.GroupBy(c => string.IsNullOrWhiteSpace(c.Id) ? Guid.NewGuid().ToString() : c.Id)
+					.Select(g => g.First())
+					.OrderBy(c => c.CreatedTime)
+					.ToList();
+
+				if (checkShare)
+				{
+					await PopulateShareFlagsAsync(page, comments, postUrl, cancellationToken);
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, "Error scraping Facebook comments");
+			}
+
+			return comments;
+		}
+
+		private static string NormalizeToMobileBasic(string url)
+		{
+			try
+			{
+				var uri = new Uri(url);
+				var builder = new UriBuilder(uri)
+				{
+					Host = uri.Host.Replace("www.facebook.com", "mbasic.facebook.com").Replace("m.facebook.com", "mbasic.facebook.com")
+				};
+				return builder.Uri.ToString();
+			}
+			catch
+			{
+				return url;
+			}
+		}
+
+		private static async Task EnsureBrowsersInstalled(IPlaywright playwright, CancellationToken cancellationToken)
+		{
+			try
+			{
+				// No-op in most environments if already installed. Programmatic install fallback.
+				await Microsoft.Playwright.Program.Main(new[] { "install" });
+			}
+			catch
+			{
+				// Ignore install errors; CreateAsync will fail later if missing
+			}
+		}
+
+		private static async Task<List<FacebookComment>> ExtractCommentsFromCurrentPageAsync(IPage page)
+		{
+			var results = new List<FacebookComment>();
+
+			// mbasic renders comments inside divs following the story, using anchors for user and small/abbr for time
+			var commentBlocks = await page.QuerySelectorAllAsync("div[role='article'] div > div");
+			foreach (var block in commentBlocks)
+			{
+				try
+				{
+					var userAnchor = await block.QuerySelectorAsync("a[href*='facebook.com']");
+					var messageSpan = await block.QuerySelectorAsync("div, span, p");
+					var timeAbbr = await block.QuerySelectorAsync("abbr, small");
+
+					if (userAnchor == null || messageSpan == null)
+					{
+						continue;
+					}
+
+					var userName = (await userAnchor.InnerTextAsync()).Trim();
+					var userHref = await userAnchor.GetAttributeAsync("href");
+					var message = (await messageSpan.InnerTextAsync()).Trim();
+					var timeText = timeAbbr != null ? (await timeAbbr.InnerTextAsync()).Trim() : string.Empty;
+
+					var created = ParseRelativeTime(timeText) ?? DateTime.UtcNow;
+
+					results.Add(new FacebookComment
+					{
+						Id = string.Empty,
+						Message = message,
+						From = new FacebookUser
+						{
+							Id = string.Empty,
+							Name = userName,
+							Picture = new FacebookPicture { Data = new FacebookPictureData { Url = string.Empty } },
+							ProfileUrl = ResolveAbsoluteUrl(page.Url, userHref ?? string.Empty)
+						},
+						CreatedTime = created,
+						CommentCount = 0,
+						LikeCount = 0,
+						IsHidden = false,
+						CanReply = false
+					});
+				}
+				catch
+				{
+					// Ignore individual comment parse failures
+				}
+			}
+
+			return results;
+		}
+
+		private static string ResolveAbsoluteUrl(string baseUrl, string href)
+		{
+			try
+			{
+				var baseUri = new Uri(baseUrl);
+				return new Uri(baseUri, href).ToString();
+			}
+			catch
+			{
+				return href;
+			}
+		}
+
+		private static DateTime? ParseRelativeTime(string text)
+		{
+			if (string.IsNullOrWhiteSpace(text)) return null;
+			text = text.Trim().ToLowerInvariant();
+
+			try
+			{
+				if (text.Contains("just now")) return DateTime.UtcNow;
+				if (text.Contains("minute")) return DateTime.UtcNow.AddMinutes(-ExtractLeadingInt(text));
+				if (text.Contains("hour")) return DateTime.UtcNow.AddHours(-ExtractLeadingInt(text));
+				if (text.Contains("day")) return DateTime.UtcNow.AddDays(-ExtractLeadingInt(text));
+				if (text.Contains("week")) return DateTime.UtcNow.AddDays(-7 * ExtractLeadingInt(text));
+				if (text.Contains("month")) return DateTime.UtcNow.AddMonths(-Math.Max(1, ExtractLeadingInt(text)));
+				if (text.Contains("year")) return DateTime.UtcNow.AddYears(-Math.Max(1, ExtractLeadingInt(text)));
+			}
+			catch { }
+
+			return null;
+		}
+
+		private static int ExtractLeadingInt(string text)
+		{
+			var digits = new string(text.TakeWhile(c => char.IsDigit(c)).ToArray());
+			return int.TryParse(digits, out var n) ? n : 1;
+		}
+
+		private static async Task PopulateShareFlagsAsync(IPage page, List<FacebookComment> comments, string targetPostUrl, CancellationToken cancellationToken)
+		{
+			// Limit concurrency to avoid rate-limits/blocks
+			var semaphore = new SemaphoreSlim(2);
+			var tasks = comments.Select(async comment =>
+			{
+				await semaphore.WaitAsync(cancellationToken);
+				try
+				{
+					if (string.IsNullOrWhiteSpace(comment.From.ProfileUrl)) return;
+					var profilePage = await page.Context.NewPageAsync();
+					await profilePage.GotoAsync(NormalizeToMobileBasic(comment.From.ProfileUrl), new PageGotoOptions { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 45000 });
+					var found = await profilePage.Locator($"a[href*='{new Uri(targetPostUrl).AbsolutePath}']").First.Or(new LocatorFilterOptions()).CountAsync() > 0;
+					comment.HasSharedPost = found;
+					await profilePage.CloseAsync();
+				}
+				catch
+				{
+					comment.HasSharedPost = false;
+				}
+				finally
+				{
+					semaphore.Release();
+				}
+			});
+
+			await Task.WhenAll(tasks);
+		}
+	}
+}

--- a/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Services/IFacebookScrapeService.cs
+++ b/facebook-comment-analyzer/backend/FacebookCommentAnalyzer.API/Services/IFacebookScrapeService.cs
@@ -1,0 +1,9 @@
+using FacebookCommentAnalyzer.API.Models;
+
+namespace FacebookCommentAnalyzer.API.Services
+{
+	public interface IFacebookScrapeService
+	{
+		Task<List<FacebookComment>> ScrapeCommentsAsync(string postUrl, bool checkShare, CancellationToken cancellationToken = default);
+	}
+}

--- a/facebook-comment-analyzer/frontend/facebook-comment-frontend/src/services/facebookService.js
+++ b/facebook-comment-analyzer/frontend/facebook-comment-frontend/src/services/facebookService.js
@@ -156,4 +156,14 @@ export const facebookService = {
   async getConfig() {
     return await apiClient.get('/config')
   }
+,
+  /**
+   * Scrape comments from a public Facebook post URL (supports public group posts)
+   * @param {string} postUrl - Public Facebook post URL
+   * @param {boolean} checkShare - Whether to try detect if commenters shared the post
+   * @returns {Promise<Array>} Array of scraped comments
+   */
+  async scrapeComments(postUrl, checkShare = false) {
+    return await apiClient.post('/scrape-comments', { postUrl, checkShare })
+  }
 }


### PR DESCRIPTION
Add Facebook public post comment scraping functionality to retrieve comments, user profile URLs, and detect post shares without requiring an access token.

This provides an alternative to the existing Graph API integration, allowing data extraction from public posts and groups where Graph API access might be restricted or require specific permissions/tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fbc3902-b42b-4e75-a629-d8a8c3e9b1ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fbc3902-b42b-4e75-a629-d8a8c3e9b1ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

